### PR TITLE
[FEAT] Refactored to allow for interaction with a subfolder in a web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ yarn
 yarn start
 ```
 
+- To Build
+```bash
+yarn build
+```
+
+if you want to build for a specific subdirectory
+
+```bash
+yarn build --env rootPath=/<path>/<to>/<subfolder>/
+
+```
+
 ### Storybook
 
 Run inside another terminal:

--- a/public/build.manifest.json
+++ b/public/build.manifest.json
@@ -18,7 +18,7 @@
       "sizes": "26x256"
     }
   ],
-  "start_url": "/home",
+  "start_url": "$ROOT_PATHhome",
   "display": "standalone",
   "theme_color": "#000000",
   "background_color": "#ffffff"

--- a/public/index.html
+++ b/public/index.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-root-path="<%= htmlWebpackPlugin.options.rootPath %>">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" href="<%= htmlWebpackPlugin.options.rootPath %>favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="<%= htmlWebpackPlugin.options.rootPath %>apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="<%= htmlWebpackPlugin.options.rootPath %>favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="<%= htmlWebpackPlugin.options.rootPath %>favicon-16x16.png" />
 
-    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
+    <link rel="mask-icon" href="<%= htmlWebpackPlugin.options.rootPath %>safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#00aba9" />
     <meta name="ui-version" content="%REACT_APP_GIT_SHA%" />
 
@@ -28,7 +28,7 @@
       property="og:description"
       content="The all-in-one DEX on Fantom. A complete hub for trading, lending, staking delegations, farming, and much more."
     />
-    <meta property="og:image" content="/images/embed-banner.png" />
+    <meta property="og:image" content="<%= htmlWebpackPlugin.options.rootPath %>images/embed-banner.png" />
 
     <!-- Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image" />
@@ -37,13 +37,13 @@
       name="twitter:description"
       content="The all-in-one DEX on Fantom. A complete hub for trading, lending, staking delegations, farming, and much more."
     />
-    <meta name="twitter:image" content="/images/embed-banner.png" />
+    <meta name="twitter:image" content="<%= htmlWebpackPlugin.options.rootPath %>images/embed-banner.png" />
 
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="<%= htmlWebpackPlugin.options.rootPath %>manifest.json" />
 
     <link
       href="https://fonts.googleapis.com/css?family=Jost"

--- a/src/app/components/Dropdown/Dropdown.tsx
+++ b/src/app/components/Dropdown/Dropdown.tsx
@@ -3,7 +3,7 @@ import React, { FC } from 'react';
 import { Props } from './Dropdown.d';
 import { Wrapper, Button } from './styles';
 import ImageLogo from '../ImageLogo';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'app/hooks/Routing';
 
 const Dropdown: FC<Props> = ({
   items,

--- a/src/app/components/ImageLogo/index.tsx
+++ b/src/app/components/ImageLogo/index.tsx
@@ -1,6 +1,7 @@
 import { Flex, Image } from '@chakra-ui/react';
 import { useMemo } from 'react';
 import { QuestionIcon } from 'app/assets/icons';
+import { resolveRoutePath } from 'app/router/routes';
 
 export default function ImageLogo({
   symbol,
@@ -27,8 +28,10 @@ export default function ImageLogo({
 }) {
   let upperCaseSymbol = symbol?.toUpperCase();
   const srcs: string = useMemo(() => {
-    if (type === 'network') return `/images/networks/${symbol}.png`;
-    if (type === 'languages') return `/images/languages/${upperCaseSymbol}.png`;
+    if (type === 'network')
+      return resolveRoutePath(`images/networks/${symbol}.png`);
+    if (type === 'languages')
+      return resolveRoutePath(`images/languages/${upperCaseSymbol}.png`);
 
     return getTokenImageUrl(upperCaseSymbol);
   }, [upperCaseSymbol, symbol, type]);
@@ -44,7 +47,7 @@ export default function ImageLogo({
           margin={margin}
           src={src ?? srcs}
           alt={`${upperCaseSymbol ?? 'token'} logo`}
-          fallbackSrc="/images/tokens/default.png"
+          fallbackSrc={resolveRoutePath('images/tokens/default.png')}
           fallbackStrategy="onError"
         />
       ) : (
@@ -55,4 +58,4 @@ export default function ImageLogo({
 }
 
 export const getTokenImageUrl = (symbol?: string) =>
-  `/images/tokens/${symbol?.toUpperCase()}.png`;
+  resolveRoutePath(`images/tokens/${symbol?.toUpperCase()}.png`);

--- a/src/app/components/Menu/NewDropdown.tsx
+++ b/src/app/components/Menu/NewDropdown.tsx
@@ -8,7 +8,7 @@ import {
 } from '@chakra-ui/react';
 import { DotOutlineIcon } from 'app/assets/icons';
 import { Props } from './NewDropdown.d';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'app/hooks/Routing';
 
 const NewDropdown = ({ items, address, migrateItem }: Props) => {
   const navigate = useNavigate();

--- a/src/app/components/ModalToken/ModalToken.tsx
+++ b/src/app/components/ModalToken/ModalToken.tsx
@@ -23,6 +23,7 @@ import { CommonTokens } from '../CommonTokens';
 import { useTokenBalances } from 'app/hooks/useTokenBalances';
 import { List } from 'react-virtualized';
 import useWallets from 'app/hooks/useWallets';
+import { resolveRoutePath } from 'app/router/routes';
 
 const ModalToken = ({
   tokens,
@@ -66,7 +67,7 @@ const ModalToken = ({
           if (findToken) {
             const path =
               findToken.chainId === 250
-                ? `/images/tokens/${findToken.symbol}.png`
+                ? resolveRoutePath(`images/tokens/${findToken.symbol}.png`)
                 : findToken.logoURI;
 
             return {
@@ -110,7 +111,7 @@ const ModalToken = ({
           ) {
             const path =
               liFinanceToken.chainId === 250
-                ? `/images/tokens/${liFinanceToken.symbol}.png`
+                ? resolveRoutePath(`images/tokens/${liFinanceToken.symbol}.png`)
                 : liFinanceToken.logoURI;
 
             return {

--- a/src/app/components/NavigationDropdown/NavigationDropdown.tsx
+++ b/src/app/components/NavigationDropdown/NavigationDropdown.tsx
@@ -26,6 +26,7 @@ import {
   MoneyHandIcon,
 } from 'app/assets/icons';
 import { openInNewTab } from 'app/utils/redirectTab';
+import { resolveRoutePath } from 'app/router/routes';
 
 const NavigationDropdown: FC<Props> = ({
   items,
@@ -78,7 +79,7 @@ const NavigationDropdown: FC<Props> = ({
     const link = item.path ? (
       <StyledNavLink
         key={item.path}
-        to={item.path}
+        to={resolveRoutePath(item.path)}
         onClick={onClickOutside}
         end={true}
       >

--- a/src/app/components/NewTokenAmountPanel/NewTokenAmountPanel.tsx
+++ b/src/app/components/NewTokenAmountPanel/NewTokenAmountPanel.tsx
@@ -35,6 +35,7 @@ import { TOKENS_BRIDGE } from 'constants/bridgeTokens';
 import useLogin from 'app/connectors/EthersConnector/login';
 import { selectIsLoggedIn } from 'store/user/selectors';
 import { useAppSelector } from 'store/hooks';
+import { LIQUIDITY, BRIDGE, resolveRoutePath } from 'app/router/routes';
 
 const NewTokenAmountPanel = ({
   token,
@@ -74,8 +75,6 @@ const NewTokenAmountPanel = ({
   ...props
 }: Props) => {
   const { t } = useTranslation();
-  const LIQUIDITY_PATH = '/liquidity';
-  const BRIDGE_PATH = '/bridge';
   const { pathname } = useLocation();
   const { handleLogin } = useLogin();
   const [mustShowPercentage, setMustShowPercentage] = useState(showPercentage);
@@ -246,10 +245,10 @@ const NewTokenAmountPanel = ({
 
   const commonTokens = () => {
     if (notShowCommonBase) return [];
-    if (pathname === BRIDGE_PATH) {
+    if (pathname === resolveRoutePath(BRIDGE.path)) {
       return [];
     }
-    if (pathname === LIQUIDITY_PATH) return LIQUIDITY_TOKENS;
+    if (pathname === resolveRoutePath(LIQUIDITY.path)) return LIQUIDITY_TOKENS;
     return isOutput ? SECOND_TOKEN_AMOUNT_PANEL : FIRST_TOKEN_AMOUNT_PANEL;
   };
 
@@ -257,7 +256,9 @@ const NewTokenAmountPanel = ({
 
   const getSRC = () => {
     if (token?.chainId === 250 && token.symbol)
-      return `/images/tokens/${token.symbol.toUpperCase()}.png`;
+      return resolveRoutePath(
+        `images/tokens/${token.symbol.toUpperCase()}.png`,
+      );
     return token?.logoURI;
   };
 

--- a/src/app/components/PageFooter/PageFooter.tsx
+++ b/src/app/components/PageFooter/PageFooter.tsx
@@ -28,7 +28,7 @@ import { setShowPortfolio } from 'store/user';
 import { useAppSelector } from 'store/hooks';
 import { selectIsLoggedIn, selectShowPortfolio } from 'store/user/selectors';
 import { selectIsHomePage } from 'store/general/selectors';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'app/hooks/Routing';
 import {
   ZOKYO_AUDIT_URL,
   PECK_SHIELD_AUDIT_URL,
@@ -48,7 +48,7 @@ export default function PageFooter() {
 
   const onClickLandingButton = () => {
     dispatch(setShowPortfolio(false));
-    navigate('/');
+    navigate('');
   };
   const isLoggedIn = useAppSelector(selectIsLoggedIn);
   const isPortfolioShown = useAppSelector(selectShowPortfolio);

--- a/src/app/hooks/Routing/index.ts
+++ b/src/app/hooks/Routing/index.ts
@@ -1,0 +1,1 @@
+export { default as useNavigate } from './useNavigate';

--- a/src/app/hooks/Routing/useNavigate.ts
+++ b/src/app/hooks/Routing/useNavigate.ts
@@ -1,0 +1,12 @@
+import { useNavigate as useNavigateOriginal } from 'react-router-dom';
+import { resolveRoutePath } from 'app/router/routes';
+
+const useNavigate = () => {
+  const navigate = useNavigateOriginal();
+  return (path, ...others) => {
+    const resolvedPath = resolveRoutePath(path);
+    return navigate(resolvedPath, ...others);
+  };
+};
+
+export default useNavigate;

--- a/src/app/hooks/Suggestions/useSuggestion.tsx
+++ b/src/app/hooks/Suggestions/useSuggestion.tsx
@@ -2,7 +2,14 @@ import React from 'react';
 import { Suggestion } from './Suggestion';
 import { Button, ToastId, useToast } from '@chakra-ui/react';
 import { useSuggestionsProps, SuggestionsTypes } from './Suggestion';
-import { FARMS, HOME, INSPIRIT, LIQUIDITY, SWAP } from 'app/router/routes';
+import {
+  FARMS,
+  HOME,
+  INSPIRIT,
+  LIQUIDITY,
+  SWAP,
+  resolveRoutePath,
+} from 'app/router/routes';
 import { openInSelfTab } from 'app/utils/redirectTab';
 import { useAppSelector } from 'store/hooks';
 import { selectUserSettings } from 'store/settings/selectors';
@@ -64,7 +71,11 @@ export function useSuggestion() {
   const farmButton = (lpAddress?: string) => (
     <Button
       onClick={() =>
-        openInSelfTab(lpAddress ? `${FARMS.path}/${lpAddress}` : LIQUIDITY.path)
+        openInSelfTab(
+          lpAddress
+            ? `${resolveRoutePath(FARMS.path)}/${lpAddress}`
+            : resolveRoutePath(LIQUIDITY.path),
+        )
       }
     >
       {t(`${translationPath}.buttons.farms`)}
@@ -72,7 +83,7 @@ export function useSuggestion() {
   );
 
   const portfolioButton = (
-    <Button onClick={() => openInSelfTab(HOME.path)}>
+    <Button onClick={() => openInSelfTab(resolveRoutePath(HOME.path))}>
       {t(`${translationPath}.buttons.portfolio`)}
     </Button>
   );
@@ -85,7 +96,7 @@ export function useSuggestion() {
   // );
 
   const swapButton = (
-    <Button onClick={() => openInSelfTab(SWAP.path)}>
+    <Button onClick={() => openInSelfTab(resolveRoutePath(SWAP.path))}>
       {t(`${translationPath}.buttons.swap`)}
     </Button>
   );
@@ -102,7 +113,7 @@ export function useSuggestion() {
               block: 'end',
             });
           }
-          openInSelfTab(INSPIRIT.path);
+          openInSelfTab(resolveRoutePath(INSPIRIT.path));
         }}
       >
         {t(`${translationPath}.buttons.${textContent}`)}
@@ -115,8 +126,8 @@ export function useSuggestion() {
       onClick={() =>
         openInSelfTab(
           tokenA && tokenB
-            ? `${LIQUIDITY.path}/${tokenA}/${tokenB}`
-            : LIQUIDITY.path,
+            ? `${resolveRoutePath(LIQUIDITY.path)}/${tokenA}/${tokenB}`
+            : resolveRoutePath(LIQUIDITY.path),
         )
       }
     >

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -2,7 +2,7 @@ import { Helmet } from 'react-helmet-async';
 
 import { GlobalStyle } from '../styles/global-styles';
 import { useTranslation } from 'react-i18next';
-import { SiteRouting } from 'app/router';
+import { SiteRouting, RootPathContext } from 'app/router';
 
 import Layers from './assets/background';
 import { Box } from '@chakra-ui/react';
@@ -15,6 +15,7 @@ const GlobalStyleProxy: any = GlobalStyle;
 export function App() {
   const { i18n } = useTranslation();
   const [spiritPrice, setSpiritPrice] = useState(0);
+  const rootPath = document.documentElement.dataset['rootPath'] || '/';
   useEffect(() => {
     const fetchPrice = async () => {
       const data = await getTokenUsdPrice(SPIRIT.address, CHAIN_ID);
@@ -29,7 +30,7 @@ export function App() {
   const Layout = ({ children }) => <Box>{children}</Box>;
 
   return (
-    <>
+    <RootPathContext.Provider value={rootPath}>
       <Helmet
         titleTemplate={`SpiritSwap - $${spiritPrice.toFixed(3)}`}
         defaultTitle={`SpiritSwap - $${spiritPrice.toFixed(3)}`}
@@ -45,6 +46,6 @@ export function App() {
           <SiteRouting />
         </>
       </Layout>
-    </>
+    </RootPathContext.Provider>
   );
 }

--- a/src/app/layouts/Footer/Footer.tsx
+++ b/src/app/layouts/Footer/Footer.tsx
@@ -47,6 +47,7 @@ import {
   NFTS,
   SWAP,
   SPIRITWARS,
+  resolveRoutePath,
 } from 'app/router/routes';
 import { useAppDispatch } from 'store/hooks';
 import { setUnexpectedError } from 'store/errors';
@@ -78,7 +79,7 @@ const NavMenuItem = ({ menu, is_active }: NavMenuProps) => {
 
   return (
     <StyledMenuItem
-      to={menu.path}
+      to={resolveRoutePath(menu.path)}
       $is_active={is_active}
       onClick={handleResetError}
     >
@@ -95,11 +96,11 @@ const Footer = () => {
   const translatedNavMenus = navMenus.map(menu => ({
     title: t(`${menuTranslationPath}.${menu.key}`),
     image: menu.image,
-    path: menu.path,
+    path: resolveRoutePath(menu.path),
   }));
   const translatedDropdownMenus = navDropdownMenus.map((menu: any) => ({
     title: t(`${menuTranslationPath}.${menu.key}`),
-    path: menu.path,
+    path: resolveRoutePath(menu.path),
     url: menu.url,
   }));
 
@@ -120,7 +121,7 @@ const Footer = () => {
   useEffect(() => {
     setMenuIndex(
       [...translatedNavMenus, ...translatedDropdownMenus].findIndex(
-        menu => location.pathname === menu.path,
+        menu => location.pathname === resolveRoutePath(menu.path),
       ),
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/app/layouts/Footer/Footer.tsx
+++ b/src/app/layouts/Footer/Footer.tsx
@@ -96,11 +96,11 @@ const Footer = () => {
   const translatedNavMenus = navMenus.map(menu => ({
     title: t(`${menuTranslationPath}.${menu.key}`),
     image: menu.image,
-    path: resolveRoutePath(menu.path),
+    path: menu.path,
   }));
   const translatedDropdownMenus = navDropdownMenus.map((menu: any) => ({
     title: t(`${menuTranslationPath}.${menu.key}`),
-    path: resolveRoutePath(menu.path),
+    path: menu.path,
     url: menu.url,
   }));
 
@@ -121,7 +121,7 @@ const Footer = () => {
   useEffect(() => {
     setMenuIndex(
       [...translatedNavMenus, ...translatedDropdownMenus].findIndex(
-        menu => location.pathname === resolveRoutePath(menu.path),
+        menu => location.pathname === menu.path,
       ),
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/app/layouts/Footer/__tests__/__snapshots__/Footer.test.tsx.snap
+++ b/src/app/layouts/Footer/__tests__/__snapshots__/Footer.test.tsx.snap
@@ -107,27 +107,6 @@ Object {
   border-radius: 8px 8px 0 0;
 }
 
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  padding: 4px 0;
-  gap: 2px;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  background: rgba(100,221,192,0.15);
-  color: #60E6C5;
-  border-radius: 4px;
-}
-
 .c6 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -153,19 +132,19 @@ Object {
   color: #FFFFFF;
 }
 
+.c10 {
+  color: #FFFFFF;
+}
+
 .c11 {
-  color: #60E6C5;
+  color: #FFFFFF;
+}
+
+.c14 {
+  color: #FFFFFF;
 }
 
 .c12 {
-  color: #FFFFFF;
-}
-
-.c15 {
-  color: #FFFFFF;
-}
-
-.c13 {
   color: #FFFFFF;
 }
 
@@ -178,7 +157,7 @@ Object {
   line-height: 20px;
 }
 
-.c14 {
+.c13 {
   background: transparent;
   border-radius: 4px;
   display: -webkit-box;
@@ -197,14 +176,14 @@ Object {
   position: relative;
 }
 
-.c16 {
+.c15 {
   color: #FFFFFF;
   font-family: Jost,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
   font-size: 10px;
   line-height: 20px;
 }
 
-.c17 {
+.c16 {
   position: absolute;
   right: 0;
   bottom: 62px;
@@ -355,14 +334,14 @@ Object {
             </span>
           </a>
           <a
-            class="c10"
+            class="c6"
             href="/swap"
           >
             <div
               class="c7"
             >
               <svg
-                class="c11"
+                class="c10"
               >
                 menu-swap.svg
               </svg>
@@ -381,7 +360,7 @@ Object {
               class="c7"
             >
               <svg
-                class="c12"
+                class="c11"
               >
                 menu-liquidity.svg
               </svg>
@@ -400,7 +379,7 @@ Object {
               class="c7"
             >
               <svg
-                class="c13"
+                class="c12"
               >
                 menu-inspirit.svg
               </svg>
@@ -412,24 +391,24 @@ Object {
             </span>
           </a>
           <div
-            class="c14"
+            class="c13"
           >
             <div
               class="c7"
             >
               <svg
-                class="c15"
+                class="c14"
               >
                 menu-dots.svg
               </svg>
             </div>
             <span
-              class="c16"
+              class="c15"
             >
               More
             </span>
             <div
-              class="c17"
+              class="c16"
             />
           </div>
         </div>
@@ -528,14 +507,14 @@ Object {
           </span>
         </a>
         <a
-          class="sc-crHmcD eYpDcT"
+          class="sc-crHmcD eQgfhF"
           href="/swap"
         >
           <div
             class="sc-jRQBWg fNjUei"
           >
             <svg
-              class="sc-bqiRlB fMnJPG"
+              class="sc-bqiRlB kPEcTd"
             >
               menu-swap.svg
             </svg>

--- a/src/app/layouts/TopBar/TopBar.tsx
+++ b/src/app/layouts/TopBar/TopBar.tsx
@@ -1,5 +1,6 @@
 import { FC, useEffect, useCallback, useState, useRef } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { useNavigate } from 'app/hooks/Routing';
 import { useTranslation } from 'react-i18next';
 import { NavigationDropdown } from 'app/components/NavigationDropdown';
 import { ConnectWallet } from 'app/components/ConnectWallet';
@@ -67,6 +68,7 @@ import {
   APEMODE,
   SPIRITWARS,
   BUYFTM,
+  resolveRoutePath,
 } from 'app/router/routes';
 import { openInNewTab } from 'app/utils/redirectTab';
 import { useAppDispatch, useAppSelector } from 'store/hooks';
@@ -114,7 +116,7 @@ const NavMenuItem = ({ menu, is_active }: NavMenuProps) => {
 
   return (
     <StyledMenuItem
-      to={menu.path}
+      to={resolveRoutePath(menu.path)}
       $is_active={is_active}
       onClick={handleResetError}
     >
@@ -203,7 +205,7 @@ const TopBar: FC<Props> = () => {
     : null;
 
   useEffect(() => {
-    if (window.location.pathname === '/home') {
+    if (window.location.pathname === resolveRoutePath(HOME.path)) {
       dispatch(setIsHomePage(true));
     } else {
       dispatch(setIsHomePage(false));
@@ -248,7 +250,7 @@ const TopBar: FC<Props> = () => {
   };
 
   const navigateHome = () => {
-    navigate('/home');
+    navigate(HOME.path);
   };
 
   const openConnectWalletModal = () => {
@@ -263,7 +265,7 @@ const TopBar: FC<Props> = () => {
   useEffect(() => {
     setMenuIndex(
       [...navMenuItems, ...navDropdownItems].findIndex(menu =>
-        location.pathname.includes(menu.path),
+        location.pathname.includes(resolveRoutePath(menu.path)),
       ),
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -403,7 +405,10 @@ const TopBar: FC<Props> = () => {
           </MenuWrapper>
           <HStack spacing="spacing03" justify="end" flex="1" mr="spacing04">
             {!isMobile && (
-              <StyledMenuItem to="/swap" $is_active={false}>
+              <StyledMenuItem
+                to={resolveRoutePath(SWAP.path)}
+                $is_active={false}
+              >
                 <Button fontSize="base" fontWeight="normal">
                   <SoullyIcon />
                   <Skeleton

--- a/src/app/pages/ApeMode/ApeModePlaceholder.tsx
+++ b/src/app/pages/ApeMode/ApeModePlaceholder.tsx
@@ -1,8 +1,9 @@
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'app/hooks/Routing';
 import { PlaceholderScreen } from 'app/components/PlaceholderScreen';
 import { ReactComponent as ApeModeImage } from 'app/assets/apemode/wip.svg';
 import { Helmet, HelmetProvider } from 'react-helmet-async';
+import { HOME } from 'app/router/routes';
 
 const ApeModePlaceholder = () => {
   const navigate = useNavigate();
@@ -17,7 +18,7 @@ const ApeModePlaceholder = () => {
       {
         type: 'secondary',
         label: t('apeMode.wip.buttons.back'),
-        action: () => navigate('/home'),
+        action: () => navigate(HOME.path),
       },
     ],
   };

--- a/src/app/pages/Errors/NotFoundPage.tsx
+++ b/src/app/pages/Errors/NotFoundPage.tsx
@@ -1,7 +1,8 @@
-import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { PlaceholderScreen } from 'app/components/PlaceholderScreen';
 import { ReactComponent as NotFound } from 'app/assets/errors/404.svg';
+import { HOME } from 'app/router/routes';
+import { useNavigate } from 'app/hooks/Routing';
 
 const NotFoundPage = () => {
   const navigate = useNavigate();
@@ -14,7 +15,7 @@ const NotFoundPage = () => {
       {
         type: 'primary',
         label: t('common.errors.404.buttons.back'),
-        action: () => navigate('/home'),
+        action: () => navigate(HOME.path),
       },
     ],
   };

--- a/src/app/pages/Errors/UnexpectedErrorPage.tsx
+++ b/src/app/pages/Errors/UnexpectedErrorPage.tsx
@@ -1,9 +1,10 @@
-import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as UnexpectedError } from 'app/assets/errors/500.svg';
 import PlaceholderScreen from 'app/components/PlaceholderScreen/PlaceholderScreen';
 import { useAppDispatch } from 'store/hooks';
 import { setUnexpectedError } from 'store/errors';
+import { HOME } from 'app/router/routes';
+import { useNavigate } from 'app/hooks/Routing';
 
 const UnexpectedErrorPage = () => {
   const navigate = useNavigate();
@@ -24,7 +25,7 @@ const UnexpectedErrorPage = () => {
         label: t('common.errors.500.buttons.back'),
         action: () => {
           dispatch(setUnexpectedError(false));
-          navigate('/home');
+          navigate(HOME.path);
         },
       },
     ],

--- a/src/app/pages/Farms/Farm/Farm.tsx
+++ b/src/app/pages/Farms/Farm/Farm.tsx
@@ -11,7 +11,7 @@ import Web3Monitoring from 'app/connectors/EthersConnector/transactions';
 import { transactionResponse } from 'utils/web3/actions/utils';
 import { checkAddress, getRoundedSFs } from 'app/utils';
 import { SuggestionsTypes } from 'app/hooks/Suggestions/Suggestion';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'app/hooks/Routing';
 import {
   Button,
   SimpleGrid,
@@ -39,6 +39,7 @@ import BigNumber from 'bignumber.js';
 import { formatUnits } from 'ethers/lib/utils';
 import { Props } from './Farm.d';
 import useGetTokensPrices from 'app/hooks/useGetTokensPrices';
+import { LIQUIDITY, resolveRoutePath } from 'app/router/routes';
 
 export const Farm = ({
   farm,
@@ -278,7 +279,7 @@ export const Farm = ({
   const getUrl = () => {
     const token0 = tokens[0] === 'WFTM' ? 'FTM' : tokens[0];
     const token1 = tokens[1] === 'WFTM' ? 'FTM' : tokens[1];
-    return `/liquidity/${token0}/${token1}/${type}`;
+    return `${LIQUIDITY.path}/${token0}/${token1}/${type}`;
   };
 
   const staked = Number(farmUserData.lpTokens) > 0;

--- a/src/app/pages/Farms/Farms.tsx
+++ b/src/app/pages/Farms/Farms.tsx
@@ -10,7 +10,8 @@ import { GetWalletBalance } from 'app/utils';
 import debounce from 'lodash/debounce';
 import { Helmet, HelmetProvider } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
+import { useNavigate } from 'app/hooks/Routing';
 import { resetEcosystemValues, setEcosystemFarmAddress } from 'store/farms';
 import {
   selectEcosystemValues,
@@ -38,6 +39,7 @@ import { FarmCreateModal } from './components/FarmCreateModal';
 import { ethers } from 'ethers';
 import useWallets from 'app/hooks/useWallets';
 import useLogin from 'app/connectors/EthersConnector/login';
+import { FARMS as FARMS_ROUTE } from 'app/router/routes';
 
 const translationPath = 'farms.common';
 
@@ -226,7 +228,7 @@ export const Farms = () => {
   ]);
 
   const handleBackToFarms = () => {
-    navigate('/farms');
+    navigate(FARMS_ROUTE.path);
     setFarmData(farmMasterData);
     setIsLoading(false);
   };

--- a/src/app/pages/Farms/components/FarmCreateModal/FarmCreateModal.tsx
+++ b/src/app/pages/Farms/components/FarmCreateModal/FarmCreateModal.tsx
@@ -29,7 +29,7 @@ import { Props } from './FarmCreateModal.d';
 import Requirments from './Steps/Requirments';
 import Selections from './Steps/Selections';
 import { createFarm, getPairs } from 'utils/web3/actions/farm';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'app/hooks/Routing';
 import { LIQUIDITY } from 'app/router/routes';
 import { useAppSelector } from 'store/hooks';
 import {

--- a/src/app/pages/Home/Home.tsx
+++ b/src/app/pages/Home/Home.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Helmet, HelmetProvider } from 'react-helmet-async';
-import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAppDispatch, useAppSelector } from 'store/hooks';
 import { balanceReturnData, fiat, getTokenGroupStatistics } from 'utils/data';
 import { Box, Button, Flex, Stack, useDisclosure } from '@chakra-ui/react';
 import PartnersIcons from './PartnersIcons';
+import { useNavigate } from 'app/hooks/Routing';
 import {
   SwapIcon,
   FarmsIcon,
@@ -43,7 +43,14 @@ import {
   selectShowPortfolio,
   selectLimitOrdersTotalValue,
 } from 'store/user/selectors';
-import { LENDANDBORROW } from 'app/router/routes';
+import {
+  LENDANDBORROW,
+  SWAP,
+  FARMS,
+  BRIDGE,
+  INSPIRIT,
+  resolveRoutePath,
+} from 'app/router/routes';
 import { ConnectWallet } from 'app/components/ConnectWallet';
 import {
   GetInspiritData,
@@ -179,7 +186,7 @@ const Home = () => {
       id: 'swap',
       titleIcon: <SwapIcon />,
       translationPath: 'home.about.swap',
-      buttonNavPath: { path: '/swap' },
+      buttonNavPath: { path: SWAP.path },
       image: Swap,
       animation: SwapAnimation,
     },
@@ -187,7 +194,7 @@ const Home = () => {
       id: 'farms',
       titleIcon: <FarmsIcon />,
       translationPath: 'home.about.farms',
-      buttonNavPath: { path: '/farms' },
+      buttonNavPath: { path: FARMS.path },
       image: Earn,
       animation: FarmAnimation,
     },
@@ -195,7 +202,7 @@ const Home = () => {
       id: 'bridge',
       titleIcon: <BridgeIcon />,
       translationPath: 'home.about.bridge',
-      buttonNavPath: { path: '/bridge' },
+      buttonNavPath: { path: BRIDGE.path },
       image: Bridge,
       animation: BridgeAnimation,
     },
@@ -203,7 +210,7 @@ const Home = () => {
       id: 'inSpirit',
       titleIcon: <InspiritIcon />,
       translationPath: 'home.about.inspirit',
-      buttonNavPath: { path: '/inspirit' },
+      buttonNavPath: { path: INSPIRIT.path },
       image: Inspirit,
       animation: InspiritAnimation,
     },
@@ -219,7 +226,7 @@ const Home = () => {
 
   const handleGoToLanding = () => {
     dispatch(setShowPortfolio(false));
-    navigate('/');
+    navigate('');
   };
 
   const handleConnectButton = () => {
@@ -387,8 +394,8 @@ const Home = () => {
                           }
                           onButtonClick={
                             portfolioAmount
-                              ? () => navigate('/swap')
-                              : () => navigate('/bridge')
+                              ? () => navigate(SWAP.path)
+                              : () => navigate(BRIDGE.path)
                           }
                         />
                         <WalletPanel
@@ -398,7 +405,7 @@ const Home = () => {
                             spiritPrice,
                           )}
                           buttonTitle={t(`${translationPath}.showFarms`)}
-                          onButtonClick={() => navigate('/farms')}
+                          onButtonClick={() => navigate(FARMS.path)}
                         />
                       </WalletPanelWrapper>
                     )}

--- a/src/app/pages/Home/components/AboutSectionItem.tsx
+++ b/src/app/pages/Home/components/AboutSectionItem.tsx
@@ -1,5 +1,4 @@
 import { ReactNode, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { onClickUrl, openInSelfTab } from 'app/utils/redirectTab';
 import { Button } from 'app/components/Button';
@@ -11,6 +10,7 @@ import {
   AboutSectionButtonWrapper,
   AboutSectionImageWrapper,
 } from './styles';
+import { useNavigate } from 'app/hooks/Routing';
 import { LightBoxModal } from 'app/components/LightBoxModal';
 import { StyledWalletDescription } from '../styles';
 import { Box, Flex } from '@chakra-ui/react';

--- a/src/app/pages/Inspirit/components/Dashboard/index.tsx
+++ b/src/app/pages/Inspirit/components/Dashboard/index.tsx
@@ -41,7 +41,7 @@ import {
 } from '@chakra-ui/react';
 import { useClaimBribes } from '../Voting/hooks/useClaimBribes';
 import { SuggestionsTypes } from 'app/hooks/Suggestions/Suggestion';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'app/hooks/Routing';
 import {
   CompoundIcon,
   SoullyIcon,
@@ -57,6 +57,7 @@ import { useState } from 'react';
 import addresses from 'constants/contracts';
 import useWallets from 'app/hooks/useWallets';
 import useMobile from 'utils/isMobile';
+import { SWAP } from 'app/router/routes';
 
 export default function Dashboard() {
   const navigate = useNavigate();
@@ -163,7 +164,7 @@ export default function Dashboard() {
   };
 
   const onBuySpiritClick = () => {
-    navigate('/swap');
+    navigate(SWAP.path);
   };
 
   const balanceFormatted = formatNumber({

--- a/src/app/pages/Liquidity/components/Collapse/Collapse.tsx
+++ b/src/app/pages/Liquidity/components/Collapse/Collapse.tsx
@@ -19,7 +19,7 @@ import getDetailData, { LiquidityDetailProps } from '../../utils/getDetailData';
 import useMobile from 'utils/isMobile';
 import { truncateTokenValue } from 'app/utils';
 import getSobDetailData from '../../utils/getSobDetailData';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'app/hooks/Routing';
 import { weightedpools } from 'constants/weightedpools';
 import { stableSobPools } from 'constants/sobpools';
 import { useTokenBalance } from 'app/hooks/useTokenBalance';
@@ -29,6 +29,7 @@ import { getPooledData } from 'utils/web3/actions/liquidity';
 import useGetTokensPrices from 'app/hooks/useGetTokensPrices';
 import { useSelector } from 'react-redux';
 import { selectLpPrices } from 'store/general/selectors';
+import { FARMS } from 'app/router/routes';
 
 const CollapseItem = ({
   pair,
@@ -107,7 +108,7 @@ const CollapseItem = ({
   };
 
   const handleNavigateFarm = () => {
-    navigate(`/farms/${pair.address}`);
+    navigate(`${FARMS.path}/${pair.address}`);
   };
 
   const symbolsList = pair?.tokens?.map((symbol, i) => {

--- a/src/app/pages/Portfolio/components/LimitOrderPanelV2/Fotter/index.tsx
+++ b/src/app/pages/Portfolio/components/LimitOrderPanelV2/Fotter/index.tsx
@@ -1,7 +1,8 @@
 import { Box, Button } from '@chakra-ui/react';
 
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'app/hooks/Routing';
+import { SWAP } from 'app/router/routes';
 
 const LimitFooter = () => {
   const navigate = useNavigate();
@@ -12,7 +13,7 @@ const LimitFooter = () => {
       <Button
         variant="secondary"
         onClick={() =>
-          navigate('/swap/FTM/SPIRIT', {
+          navigate(`${SWAP.path}/FTM/SPIRIT`, {
             state: { limitOrderPanel: true } as {
               limitOrderPanel: boolean;
             },

--- a/src/app/pages/Portfolio/components/LimitOrderPanelV2/NotOrders/index.tsx
+++ b/src/app/pages/Portfolio/components/LimitOrderPanelV2/NotOrders/index.tsx
@@ -1,6 +1,7 @@
 import { Box, Button, Flex, Text } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'app/hooks/Routing';
+import { SWAP } from 'app/router/routes';
 
 const NotLimitOrders = () => {
   const navigate = useNavigate();
@@ -15,7 +16,7 @@ const NotLimitOrders = () => {
         <Button
           variant="primary"
           onClick={() =>
-            navigate('/swap/FTM/SPIRIT', {
+            navigate(`${SWAP.path}/FTM/SPIRIT`, {
               state: { limitOrderPanel: true } as {
                 limitOrderPanel: boolean;
               },

--- a/src/app/pages/Portfolio/components/LiquidityPanel/LiquidityPanel.tsx
+++ b/src/app/pages/Portfolio/components/LiquidityPanel/LiquidityPanel.tsx
@@ -26,7 +26,7 @@ import {
   StyledDescription,
   StyledSubtitle,
 } from './styles';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'app/hooks/Routing';
 import { List, Flex } from '@chakra-ui/react';
 import { MigratePanel } from '../MigratePanel';
 import { CHAIN_ID } from 'constants/index';
@@ -38,6 +38,7 @@ import { useAppSelector } from 'store/hooks';
 import { selectFarmRewards } from 'store/user/selectors';
 import { balanceReturnData } from 'utils/data';
 import { selectLpPrices } from 'store/general/selectors';
+import { LIQUIDITY as LIQUIDITY_ROUTE, FARMS } from 'app/router/routes';
 
 const LiquidityPanel = ({
   liquidityData,
@@ -172,7 +173,10 @@ const LiquidityPanel = ({
         disabled={!farmsWithRewards || !farmsWithRewards.length}
         onClick={openHarvestManager}
       />
-      <Button variant="secondary" onClick={() => navigate('/liquidity')}>
+      <Button
+        variant="secondary"
+        onClick={() => navigate(LIQUIDITY_ROUTE.path)}
+      >
         {t(`${translationPath}.footer.add`)}
       </Button>
     </StyledFooter>
@@ -187,7 +191,9 @@ const LiquidityPanel = ({
         <StyledNoFarmsMessage>
           {t(`${translationPath}.noFarms.${index}.message`)}
         </StyledNoFarmsMessage>
-        <Button onClick={() => navigate(!index ? '/liquidity' : '/farms')}>
+        <Button
+          onClick={() => navigate(!index ? LIQUIDITY_ROUTE.path : FARMS.path)}
+        >
           {t(`${translationPath}.noFarms.${index}.action`)}
         </Button>
       </StyledNoFarmsBody>

--- a/src/app/pages/Portfolio/components/TokensPanel/TokensPanel.tsx
+++ b/src/app/pages/Portfolio/components/TokensPanel/TokensPanel.tsx
@@ -38,11 +38,12 @@ import {
 import { TOKENS_TO_SHOW } from 'constants/index';
 import { useAppDispatch, useAppSelector } from 'store/hooks';
 import { setTokensToShow } from 'store/general';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'app/hooks/Routing';
 import { balanceReturnData, tokenData } from 'utils/data';
 import { selectTokens } from 'store/user/selectors';
 import { ArrowDiagonalIcon } from 'app/assets/icons';
 import { Button } from 'app/components/Button';
+import { BRIDGE, SWAP } from 'app/router/routes';
 
 interface Props {
   tokensData: balanceReturnData;
@@ -116,10 +117,13 @@ const TokensPanel = ({ tokensData }: Props) => {
 
   const renderFooter = (): ReactNode => (
     <StyledFooter>
-      <Button variant="secondary" onClick={() => navigate('/bridge')}>
+      <Button variant="secondary" onClick={() => navigate(BRIDGE.path)}>
         {t(`${translationPath}.footer.bridge`)}
       </Button>
-      <Button variant="secondary" onClick={() => navigate('/swap/FTM/SPIRIT')}>
+      <Button
+        variant="secondary"
+        onClick={() => navigate(`${SWAP.path}/FTM/SPIRIT`)}
+      >
         {t(`${translationPath}.footer.swap`)}
       </Button>
     </StyledFooter>
@@ -197,7 +201,7 @@ const TokensPanel = ({ tokensData }: Props) => {
           t(`${translationPath}.noTokens.message.UNVERIFIED`)}
       </StyledNoTokensMessage>
       <Stack spacing={4} direction="row" align="center">
-        <Button variant="primary" onClick={() => navigate('/bridge')}>
+        <Button variant="primary" onClick={() => navigate(BRIDGE.path)}>
           {t(`${translationPath}.noTokens.action`)}
         </Button>
         <ChakraButton

--- a/src/app/pages/Portfolio/components/inSpiritPanel/components/Footer.tsx
+++ b/src/app/pages/Portfolio/components/inSpiritPanel/components/Footer.tsx
@@ -1,5 +1,5 @@
 import { HStack, Button } from '@chakra-ui/react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'app/hooks/Routing';
 import { SparklesIcon } from 'app/assets/icons';
 import { useTranslation } from 'react-i18next';
 import { claimSpirit } from 'utils/web3';
@@ -9,6 +9,7 @@ import { truncateTokenValue } from 'app/utils';
 import { useAppSelector } from 'store/hooks';
 import { selectSpiritInfo } from 'store/general/selectors';
 import useWallets from 'app/hooks/useWallets';
+import { INSPIRIT } from 'app/router/routes';
 
 const Footer = ({ userClaimableAmount }) => {
   const { t } = useTranslation();
@@ -45,7 +46,7 @@ const Footer = ({ userClaimableAmount }) => {
         <SparklesIcon w="20px" h="20px" mr="6px" />
         {t(`${farmsTranslationPath}.claimRewards`)}
       </Button>
-      <Button onClick={() => navigate('/inspirit')} variant="secondary">
+      <Button onClick={() => navigate(INSPIRIT.path)} variant="secondary">
         Dashboard
       </Button>
     </HStack>

--- a/src/app/pages/Portfolio/components/inSpiritPanel/components/GreenBox.tsx
+++ b/src/app/pages/Portfolio/components/inSpiritPanel/components/GreenBox.tsx
@@ -3,7 +3,7 @@ import { InSpiritIcon } from 'app/layouts/TopBar/styles';
 import { IconButton } from 'app/components/IconButton';
 import { Text, Flex } from '@chakra-ui/react';
 import { GreeBoxProps } from '..';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'app/hooks/Routing';
 
 const GreenBox = ({ title, buttonTitle, navigateTo }: GreeBoxProps) => {
   const navigate = useNavigate();

--- a/src/app/pages/Portfolio/components/inSpiritPanel/inSpiritPanel.tsx
+++ b/src/app/pages/Portfolio/components/inSpiritPanel/inSpiritPanel.tsx
@@ -20,6 +20,11 @@ import {
 } from 'app/utils';
 import { selectLiquidity } from 'store/user/selectors';
 import moment from 'moment';
+import {
+  INSPIRIT as INSPIRIT_ROUTE,
+  SWAP,
+  resolveRoutePath,
+} from 'app/router/routes';
 
 const InSpiritPanel = ({ spiritData, inSpiritData }: inSpiritPanel) => {
   const { t } = useTranslation();
@@ -86,7 +91,9 @@ const InSpiritPanel = ({ spiritData, inSpiritData }: inSpiritPanel) => {
     : `${t(`${translationPath}.inSpiritReward`)} ${restTime()}`;
 
   const navigateTo =
-    amount && !inSpiritBalance ? '/inspirit' : `/swap/address/${address}`;
+    amount && !inSpiritBalance
+      ? INSPIRIT_ROUTE.path
+      : `${SWAP.path}/address/${address}`;
 
   const showLoader = isLoading;
 

--- a/src/app/pages/Swap/Swap.tsx
+++ b/src/app/pages/Swap/Swap.tsx
@@ -12,7 +12,7 @@ import {
 import { Helmet, HelmetProvider } from 'react-helmet-async';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'app/hooks/Routing';
 import Heading from './components/Heading';
 import Settings from './components/Settings';
 import SpiritsBackground from './components/Background';
@@ -57,6 +57,7 @@ import useSettings from 'app/hooks/useSettings';
 import { useTokenBalance } from 'app/hooks/useTokenBalance';
 import TWAPPanel from 'app/components/TWAP/TWAPPanel';
 import TWAPOrders from 'app/components/TWAP/TWAPOrders';
+import { SWAP } from 'app/router/routes';
 
 const SwapPage = () => {
   const { t } = useTranslation();
@@ -97,7 +98,7 @@ const SwapPage = () => {
   const setToken = (inputToken: Token, outputToken: Token) => {
     try {
       if (inputToken.symbol === outputToken.symbol) {
-        navigate('/swap/FTM/SPIRIT', { replace: true });
+        navigate(`${SWAP.path}/FTM/SPIRIT`, { replace: true });
         return [allTokens[0], allTokens[1]];
       }
       return [inputToken, outputToken];
@@ -193,14 +194,14 @@ const SwapPage = () => {
   useEffect(() => {
     if (queriedTokenOne && !queriedTokenTwo) {
       return navigate(
-        `/swap/${queriedTokenOne.symbol}/${
+        `${SWAP.path}/${queriedTokenOne.symbol}/${
           queriedTokenOne.symbol === 'SPIRIT' ? 'FTM' : 'SPIRIT'
         }`,
         { replace: true },
       );
     }
     if (!queriedTokenOne) {
-      return navigate('/swap/FTM/SPIRIT', { replace: true });
+      return navigate(`${SWAP.path}/FTM/SPIRIT`, { replace: true });
     }
   }, [queriedTokenOne, queriedTokenTwo, navigate]);
 
@@ -574,7 +575,7 @@ const SwapPage = () => {
         changeRateParams(firstToken.value, type, txType, newToken, secondToken);
       }
       navigate(
-        `/swap/${newToken.tokenSelected.symbol}/${
+        `${SWAP.path}/${newToken.tokenSelected.symbol}/${
           firstIsSameAsSecond
             ? defaultOtherToken
             : secondToken.tokenSelected.symbol
@@ -601,7 +602,7 @@ const SwapPage = () => {
       }
 
       navigate(
-        `/swap/${
+        `${SWAP.path}/${
           secondIsSameAsFirst
             ? defaultOtherToken
             : firstToken.tokenSelected.symbol
@@ -657,7 +658,7 @@ const SwapPage = () => {
     setFirstToken(token2);
     setSecondToken(token1);
     navigate(
-      `/swap/${token2.tokenSelected.symbol}/${token1.tokenSelected.symbol}`,
+      `${SWAP.path}/${token2.tokenSelected.symbol}/${token1.tokenSelected.symbol}`,
       { replace: true },
     );
     changeRateParams(firstToken.value, 0, 'swap', token2, token1);

--- a/src/app/pages/Swap/components/LimitOrders/components/Table.tsx
+++ b/src/app/pages/Swap/components/LimitOrders/components/Table.tsx
@@ -24,6 +24,7 @@ import ImageLogo from 'app/components/ImageLogo';
 import Web3Monitoring from 'app/connectors/EthersConnector/transactions';
 import { getRoundedSFs } from 'app/utils';
 import { formatUnits } from 'ethers/lib/utils';
+import { resolveRoutePath } from 'app/router/routes';
 
 const explorerLink = NETWORK[CHAIN_ID].blockExp[0];
 
@@ -196,7 +197,9 @@ const TableLimitOrders = ({
                     <ImageLogo
                       margin="0 8px 0 0"
                       symbol={row.original.tokens}
-                      src={`/images/tokens/${row.original.tokens}.png`}
+                      src={resolveRoutePath(
+                        `images/tokens/${row.original.tokens}.png`,
+                      )}
                       size="32px"
                       cw="32px"
                       display="inline-flex"

--- a/src/app/router/RootPathContext.ts
+++ b/src/app/router/RootPathContext.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const RootPathContext = createContext('/');
+
+export default RootPathContext;

--- a/src/app/router/SiteRouting.tsx
+++ b/src/app/router/SiteRouting.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useContext } from 'react';
 import { BrowserRouter, Route, Routes, Navigate } from 'react-router-dom';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Box } from '@chakra-ui/react';
@@ -26,6 +26,7 @@ import {
   LIQUIDITY,
   SPIRITWARS,
   SWAP,
+  resolveRoutePath,
 } from './routes';
 
 const SiteRouting = () => {
@@ -40,35 +41,59 @@ const SiteRouting = () => {
       >
         <div id="top-page" />
         <Routes>
-          <Route path="/" element={<Navigate to={HOME.path} />} />
-          <Route path={HOME.path} element={<HomePage />} />
-          <Route path={SWAP.path} element={<SwapPage />} />
           <Route
-            path={`${SWAP.path}/address/:address`}
+            path={resolveRoutePath()}
+            element={<Navigate to={resolveRoutePath(HOME.path)} />}
+          />
+          <Route path={resolveRoutePath(HOME.path)} element={<HomePage />} />
+          <Route path={resolveRoutePath(SWAP.path)} element={<SwapPage />} />
+          <Route
+            path={`${resolveRoutePath(SWAP.path)}/address/:address`}
             element={<SwapPage />}
           />
-          <Route path={`${SWAP.path}/:token1`} element={<SwapPage />} />{' '}
-          <Route path={`${SWAP.path}/:token1/:token2`} element={<SwapPage />} />
-          <Route path={BRIDGE.path} element={<BridgePage />} />
-          <Route path={LIQUIDITY.path} element={<LiquidityPage />} />
           <Route
-            path={`${LIQUIDITY.path}/:token1/:token2`}
+            path={`${resolveRoutePath(SWAP.path)}/:token1`}
+            element={<SwapPage />}
+          />{' '}
+          <Route
+            path={`${resolveRoutePath(SWAP.path)}/:token1/:token2`}
+            element={<SwapPage />}
+          />
+          <Route
+            path={resolveRoutePath(BRIDGE.path)}
+            element={<BridgePage />}
+          />
+          <Route
+            path={resolveRoutePath(LIQUIDITY.path)}
             element={<LiquidityPage />}
           />
           <Route
-            path={`${LIQUIDITY.path}/:token1/:token2/:type`}
+            path={`${resolveRoutePath(LIQUIDITY.path)}/:token1/:token2`}
             element={<LiquidityPage />}
           />
           <Route
-            path={`${LIQUIDITY.path}/:token1/:token2/remove`}
+            path={`${resolveRoutePath(LIQUIDITY.path)}/:token1/:token2/:type`}
             element={<LiquidityPage />}
           />
-          <Route path={FARMS.path} element={<FarmsPage />}>
-            <Route path={`${FARMS.path}/:address`} element={<FarmsPage />} />
+          <Route
+            path={`${resolveRoutePath(LIQUIDITY.path)}/:token1/:token2/remove`}
+            element={<LiquidityPage />}
+          />
+          <Route path={resolveRoutePath(FARMS.path)} element={<FarmsPage />}>
+            <Route
+              path={`${resolveRoutePath(FARMS.path)}/:address`}
+              element={<FarmsPage />}
+            />
           </Route>
-          <Route path={INSPIRIT.path} element={<InspiritPage />} />
+          <Route
+            path={resolveRoutePath(INSPIRIT.path)}
+            element={<InspiritPage />}
+          />
           {/* <Route path={APEMODE.path} element={<ApeModePage />} /> */}
-          <Route path={SPIRITWARS.path} element={<SpiritWars />} />
+          <Route
+            path={resolveRoutePath(SPIRITWARS.path)}
+            element={<SpiritWars />}
+          />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </ErrorBoundary>

--- a/src/app/router/index.ts
+++ b/src/app/router/index.ts
@@ -1,1 +1,2 @@
 export { default as SiteRouting } from './SiteRouting';
+export { default as RootPathContext } from './RootPathContext';

--- a/src/app/router/routes.ts
+++ b/src/app/router/routes.ts
@@ -2,32 +2,32 @@ import { SPIRIT_DOCS_URL } from 'constants/index';
 
 export const HOME = {
   key: 'home',
-  path: '/home',
+  path: 'home',
 };
 
 export const SWAP = {
   key: 'swap',
-  path: '/swap',
+  path: 'swap',
 };
 
 export const BRIDGE = {
   key: 'bridge',
-  path: '/bridge',
+  path: 'bridge',
 };
 
 export const LIQUIDITY = {
   key: 'liquidity',
-  path: '/liquidity',
+  path: 'liquidity',
 };
 
 export const FARMS = {
   key: 'farms',
-  path: '/farms',
+  path: 'farms',
 };
 
 export const INSPIRIT = {
   key: 'inSpirit',
-  path: '/inspirit',
+  path: 'inspirit',
 };
 
 export const LENDANDBORROW = {
@@ -68,7 +68,7 @@ export const DOCS = {
 
 export const APEMODE = {
   key: 'apemode',
-  path: '/apemode',
+  path: 'apemode',
   url: '',
 };
 
@@ -80,16 +80,42 @@ export const GOVERNANCE = {
 
 export const SPIRITWARS = {
   key: 'spiritwars',
-  path: '/spiritwars',
+  path: 'spiritwars',
   url: '',
 };
+
 export const BUYFTM = {
   key: 'buyftm',
   path: '',
   url: 'https://spiritswap.banxa.com/',
 };
+
 export const APEMODE_V1 = {
   key: 'apemode',
   path: '',
   url: 'https://swap.spiritswap.finance/#/exchange/apemode',
+};
+
+export const ROUTE_LOOKUP = {
+  [HOME.key]: HOME,
+  [SWAP.key]: SWAP,
+  [BRIDGE.key]: BRIDGE,
+  [LIQUIDITY.key]: LIQUIDITY,
+  [FARMS.key]: FARMS,
+  [INSPIRIT.key]: INSPIRIT,
+  [LENDANDBORROW.key]: LENDANDBORROW,
+  [STORE.key]: STORE,
+  [ANALYTICS.key]: ANALYTICS,
+  [IDO.key]: IDO,
+  [NFTS.key]: NFTS,
+  [DOCS.key]: DOCS,
+  [APEMODE.key]: APEMODE,
+  [GOVERNANCE.key]: GOVERNANCE,
+  [SPIRITWARS.key]: SPIRITWARS,
+  [BUYFTM.key]: BUYFTM,
+};
+
+export const resolveRoutePath = (path?: string) => {
+  const rootPath = document.documentElement.dataset['rootPath'] || '/';
+  return path ? `${rootPath}${path}` : rootPath;
 };

--- a/src/app/utils/tokenOptions.ts
+++ b/src/app/utils/tokenOptions.ts
@@ -2,6 +2,7 @@ import { CHAIN_ID, FTM } from 'constants/index';
 import { NETWORK } from 'constants/networks';
 import { verifiedTokenData } from 'utils/data/balances';
 import { verifiedLpTokenData } from 'utils/data/pools';
+import { SWAP, FARMS, ROUTE_LOOKUP } from 'app/router/routes';
 
 const Tokens = verifiedTokenData();
 const LPTokens = verifiedLpTokenData();
@@ -51,10 +52,9 @@ export const TokenOptions = (
         }
 
         if (tokenAddress === FTM.address) {
-          return navigate('/swap');
+          return navigate(SWAP.path);
         }
-
-        navigate(`/${target}/${token.symbol + '/FTM'}`);
+        navigate(`${SWAP.path}/${token.symbol}/FTM`);
       },
     };
 
@@ -72,7 +72,7 @@ export const TokenOptions = (
             return null;
           }
 
-          navigate(`/farms/${tokenAddress}`);
+          navigate(`${FARMS.path}/${tokenAddress}`);
         },
       };
 
@@ -94,11 +94,14 @@ export const TokenOptions = (
         }
 
         if (tokenAddress === FTM.address) {
-          return navigate('/swap');
+          return navigate(SWAP.path);
         }
 
+        const targetPath = ROUTE_LOOKUP[target]?.path;
         navigate(
-          `/${target}/${token.lpSymbol.replace(' LP', '').replace('-', '/')}`,
+          `${targetPath}/${token.lpSymbol
+            .replace(' LP', '')
+            .replace('-', '/')}`,
         );
       },
     };
@@ -111,7 +114,7 @@ export const TokenOptions = (
         if (!tokenAddress) {
           return null;
         }
-        navigate(`/farms/${tokenAddress}`);
+        navigate(`${FARMS.path}/${tokenAddress}`);
       },
     };
 
@@ -125,8 +128,10 @@ export const TokenOptions = (
         if (!token) {
           return null;
         }
+
+        const targetPath = ROUTE_LOOKUP[target]?.path;
         navigate(
-          `/${target}/${token.lpSymbol
+          `${targetPath}/${token.lpSymbol
             .replace(' LP', '')
             .replace('-', '/')}/remove`,
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -10271,9 +10271,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001335, caniuse-lite@^1.0.30001359:
-  version "1.0.30001364"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001364.tgz#1e118f0e933ed2b79f8d461796b8ce45398014a0"
-  integrity sha512-9O0xzV3wVyX0SlegIQ6knz+okhBB5pE0PC40MNdwcipjwpxoUEHL24uJ+gG42cgklPjfO5ZjZPme9FTSN3QT2Q==
+  version "1.0.30001444"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001444.tgz"
+  integrity sha512-ecER9xgJQVMqcrxThKptsW0pPxSae8R2RB87LNa+ivW9ppNWRHEplXcDzkCOP4LYWGj8hunXLqaiC41iBATNyg==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# [FEATURE ] NOREF 

## Description
This is an internal change to allow you to build SpiritSwap with a sub-directory.  The default is the `/` root directory and for all dev testing it uses the root so there is no effect.  You can generate a build with a sub-folder location with the following command:

`yarn build --env rootPath=/apps/spiritswap/`

Where `/app/spiritswap/` is the sub folder in the `build` folder.

The main factor is that there is a function call to resolve all links called `resolveRoutePath` that will create the right relative path for images, linkTo and navigation calls.
