### PR TITLE
fixing special case for MAI getting token1 and token 0

### DIFF
--- a/src/app/pages/Farms/components/FarmTransaction/FarmTransaction.tsx
+++ b/src/app/pages/Farms/components/FarmTransaction/FarmTransaction.tsx
@@ -44,7 +44,6 @@ const FarmTransaction = ({
   );
   const [shouldTransition, setShouldTransition] = useState(true);
   const farmsStaked = useAppSelector(selectFarmsStaked);
-  const liquidity = useAppSelector(selectLiquidityWallet);
   const lpPrices = useAppSelector(selectLpPrices);
 
   useEffect(() => {}, [account]);

--- a/src/app/pages/Liquidity/components/Collapse/Collapse.tsx
+++ b/src/app/pages/Liquidity/components/Collapse/Collapse.tsx
@@ -162,6 +162,7 @@ const CollapseItem = ({
         {detailData?.map((item: LiquidityDetailProps) => {
           return (
             <Skeleton
+              key={item.id}
               startColor="grayBorderBox"
               endColor="bgBoxLighter"
               isLoaded={detailData.length > 1}

--- a/src/utils/data/spiritwars.ts
+++ b/src/utils/data/spiritwars.ts
@@ -42,7 +42,7 @@ export const getHistoricalPegForWinSpirits = async (
 
   for (const array of results) {
     let tokenAddress = '';
-    const dataPointsArray = array.map(dataPoint => {
+    const dataPointsArray = array?.map(dataPoint => {
       const { datapointAt, fromToken, pegPercentage } = dataPoint;
       tokenAddress = fromToken;
 

--- a/src/workers/dataWorker.ts
+++ b/src/workers/dataWorker.ts
@@ -140,31 +140,6 @@ async function getFarms(provider, gaugesPromise) {
   }
 }
 
-async function getEcosystemTokenDetails(
-  farm: any,
-  getTokensDetails,
-  ecosystemFarmObject,
-  type,
-) {
-  const [firstTokenDetails, secondTokenDetails] = await Promise.all([
-    getTokensDetails(farm.token0),
-    getTokensDetails(farm.token1),
-  ]);
-
-  const lpAddress = farm[3];
-  const tokenAddress = farm[4];
-  const ecoFarms = ecosystemFarmObject(
-    farm,
-    firstTokenDetails,
-    secondTokenDetails,
-    lpAddress,
-    tokenAddress,
-    type,
-  );
-
-  return ecoFarms;
-}
-
 // =========================
 // ===== Spirit Wars =======
 // =========================


### PR DESCRIPTION
## Description

- Fix: Renaming token symbol for MAI case. 
In resume we are usign a mapped object from lifi, this obj have key/values objects where the key is the symbol of each token
we are usign the entire object then to get token0 and token1. The token symbol for MAI getting the data from the chain is `miMATIC`. this two values are not equal so we werent getting the token1 for this usdc/mai LP